### PR TITLE
fix: pin swagger-client@3.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@adobe/aio-lib-core-logging": "1.1.0",
     "cross-fetch": "^3.0.4",
     "form-data": "^3.0.0",
-    "swagger-client": "3.10.1"
+    "swagger-client": "3.9.6"
   },
   "deprecated": false,
   "description": "Adobe I/O Lib for the Developer Console",


### PR DESCRIPTION
The 3.10.x versions break our API during runtime when using swagger-client. We will eventually have to fix these issues.

## How Has This Been Tested?

npm test
npm run e2e

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
