### PR TITLE
fix: ioc-4292. correct issues with entp bindings in console api spec

### DIFF
--- a/spec/api.json
+++ b/spec/api.json
@@ -3797,7 +3797,7 @@
         ]
       }
     },
-    "/console/organizations/{orgId}/integrations/{intId}/bindings": {
+    "/console/organizations/{orgId}/integrations/entp/{intId}/bindings": {
       "post": {
         "summary": "upload and bind certificate",
         "tags": [
@@ -3844,13 +3844,22 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
-                "type": "file"
+                "type": "object",
+                "required": [
+                  "certificate"
+                ],
+                "properties": {
+                  "certificate": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
               }
             }
           },
-          "description": "certificate"
+          "description": "form data"
         },
         "responses": {
           "200": {
@@ -4048,7 +4057,7 @@
         ]
       }
     },
-    "/console/organizations/{orgId}/integrations/{intId}/bindings/{bindingId}": {
+    "/console/organizations/{orgId}/integrations/entp/{intId}/bindings/{bindingId}": {
       "delete": {
         "summary": "delete binding",
         "tags": [

--- a/src/index.js
+++ b/src/index.js
@@ -951,7 +951,7 @@ class CoreConsoleAPI {
 
     try {
       const res = await this.sdk.apis.Organizations
-        .get_console_organizations__orgId__integrations__intId__bindings(
+        .get_console_organizations__orgId__integrations_entp__intId__bindings(
           ...this.__createRequestOptions(parameters)
         )
       return res
@@ -975,7 +975,7 @@ class CoreConsoleAPI {
 
     try {
       const res = await this.sdk.apis.Organizations
-        .post_console_organizations__orgId__integrations__intId__bindings(
+        .post_console_organizations__orgId__integrations_entp__intId__bindings(
           ...this.__createRequestOptions(parameters, requestBody)
         )
       return res
@@ -998,7 +998,7 @@ class CoreConsoleAPI {
 
     try {
       const res = await this.sdk.apis.Organizations
-        .delete_console_organizations__orgId__integrations__intId__bindings__bindingId_(
+        .delete_console_organizations__orgId__integrations_entp__intId__bindings__bindingId_(
           ...this.__createRequestOptions(parameters)
         )
       return res

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -695,7 +695,7 @@ test('getBindingsForIntegration', async () => {
   const apiOptions = createSwaggerOptions()
 
   await standardTest({
-    fullyQualifiedApiName: 'Organizations.get_console_organizations__orgId__integrations__intId__bindings',
+    fullyQualifiedApiName: 'Organizations.get_console_organizations__orgId__integrations_entp__intId__bindings',
     sdkFunctionName: 'getBindingsForIntegration',
     apiParameters,
     apiOptions,
@@ -713,7 +713,7 @@ test('uploadAndBindCertificate', async () => {
   const apiOptions = createSwaggerOptions({ certificate: 'certificate' })
 
   await standardTest({
-    fullyQualifiedApiName: 'Organizations.post_console_organizations__orgId__integrations__intId__bindings',
+    fullyQualifiedApiName: 'Organizations.post_console_organizations__orgId__integrations_entp__intId__bindings',
     sdkFunctionName: 'uploadAndBindCertificate',
     apiParameters,
     apiOptions,
@@ -733,7 +733,7 @@ test('deleteBinding', async () => {
   const apiOptions = createSwaggerOptions()
 
   await standardTest({
-    fullyQualifiedApiName: 'Organizations.delete_console_organizations__orgId__integrations__intId__bindings__bindingId_',
+    fullyQualifiedApiName: 'Organizations.delete_console_organizations__orgId__integrations_entp__intId__bindings__bindingId_',
     sdkFunctionName: 'deleteBinding',
     apiParameters,
     apiOptions,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Corrected Enterprise Integrations binding endpoints for POST (uploadAndBind), GET, and DELETE (binding)
- Corrected requestBody schema in api spec for POST (uploadAndBind)

## Related Issue

https://jira.corp.adobe.com/browse/IOC-4292

## Motivation and Context

CoreConsoleAPISDK fails with 404 when calling uploadAndBindCertificate (and getBindingsForIntegration), which is mapped to a Swagger API call for: 

[`Organizations.post_console_organizations__orgId__integrations__intId__bindings`](https://github.com/adobe/aio-lib-console/blob/7ec79a21e83d8d4db6642b8ad6bb84a386a1fb14/src/index.js#L924)

```
Error: [CoreConsoleAPISDK:ERROR_UPLOAD_AND_BIND_CERTIFICATE] 404 - Not Found ("<html> <head><title>404 Not Found</title></head> <body> <center><h1>404 Not Found</h1></center> <hr><center>openresty</center> </body> </html>")
```

## How Has This Been Tested?

Tested locally with npm linked branches of:

@adobe/aio-lib-console
@adobe/aio-cli-lib-console
@adobe/aio-cli-plugin-console

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/524972/171702358-a3503787-3e84-491e-bb9c-d97e67cf5e99.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
