### PR TITLE
feat: Proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-errors": "^4",
     "@adobe/aio-lib-core-logging": "^3",
+    "@adobe/aio-lib-core-networking": "^5.0.2",
     "@adobe/aio-lib-env": "^3",
     "form-data": "^4.0.0",
     "swagger-client": "~3.18.5"

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ const logger = require('@adobe/aio-lib-core-logging')(loggerNamespace, { provide
 const { reduceError, requestInterceptorBuilder, responseInterceptor, createRequestOptions } = require('./helpers')
 const { codes } = require('./SDKErrors')
 const { DEFAULT_ENV, getCliEnv } = require('@adobe/aio-lib-env')
+const { createFetch } = require('@adobe/aio-lib-core-networking')
+const proxyFetch = createFetch()
 
 /**
  * @typedef {object} Response
@@ -223,12 +225,18 @@ class CoreConsoleAPI {
     } else {
       // init swagger client
       const spec = require('../spec/api.json')
-      const swagger = new Swagger({
+      const options = {
         spec,
         requestInterceptor: requestInterceptorBuilder(this, apiHost),
         responseInterceptor,
         usePromise: true
-      })
+      }
+      if (process.env.HTTPS_PROXY) {
+        logger.debug('Using proxy - ' + process.env.HTTPS_PROXY)
+        options.userFetch = proxyFetch
+      }
+      const swagger = new Swagger(options)
+
       /** @private */
       this.sdk = (await swagger)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -229,11 +229,8 @@ class CoreConsoleAPI {
         spec,
         requestInterceptor: requestInterceptorBuilder(this, apiHost),
         responseInterceptor,
-        usePromise: true
-      }
-      if (process.env.HTTPS_PROXY) {
-        logger.debug('Using proxy - ' + process.env.HTTPS_PROXY)
-        options.userFetch = proxyFetch
+        usePromise: true,
+        userFetch: proxyFetch
       }
       const swagger = new Swagger(options)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1145,7 +1145,6 @@ describe('proxy tests', () => {
 
   test('sdk init test with proxy', async () => {
     const sdkClient = await createSdkClient()
-    expect(mockLogger.debug.mock.calls[0][0]).toBe('Using proxy - https://fakeproxy')
     expect(sdkClient.apiKey).toBe(gApiKey)
     expect(sdkClient.accessToken).toBe(gAccessToken)
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,7 @@ const { codes } = require('../src/SDKErrors')
 const sdk = require('../src')
 const libEnv = require('@adobe/aio-lib-env')
 const { STAGE_ENV, PROD_ENV } = jest.requireActual('@adobe/aio-lib-env')
+const mockLogger = require('@adobe/aio-lib-core-logging')
 
 jest.mock('@adobe/aio-lib-env')
 
@@ -1124,5 +1125,28 @@ test('createOauthS2SCredentialIntegration', async () => {
     apiOptions,
     sdkArgs,
     ErrorClass: codes.ERROR_CREATE_OAUTH_SERVER_TO_SERVER_CREDENTIAL_INTEGRATION
+  })
+})
+describe('proxy tests', () => {
+  let ORIGINAL_HTTPS_PROXY
+
+  beforeAll(() => {
+    ORIGINAL_HTTPS_PROXY = process.env.HTTPS_PROXY
+  })
+  afterAll(() => {
+    process.env.HTTPS_PROXY = ORIGINAL_HTTPS_PROXY
+  })
+
+  beforeEach(() => {
+    process.env.HTTPS_PROXY = 'https://fakeproxy'
+    mockLogger.mockReset()
+    jest.clearAllMocks()
+  })
+
+  test('sdk init test with proxy', async () => {
+    const sdkClient = await createSdkClient()
+    expect(mockLogger.debug.mock.calls[0][0]).toBe('Using proxy - https://fakeproxy')
+    expect(sdkClient.apiKey).toBe(gApiKey)
+    expect(sdkClient.accessToken).toBe(gAccessToken)
   })
 })


### PR DESCRIPTION
Swagger client was not using the set proxy.
Added option to use networking lib proxyFetch when proxy is set.

## Description

<!--- Describe your changes in detail -->

## Related Issue
[https://github.com/adobe/aio-cli-plugin-console/issues/218](https://github.com/adobe/aio-cli-plugin-console/issues/218) 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual Proxy setup and test
unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
