### PR TITLE
fix: ACNA-3249 - node 22 has warning in every cli command (eslint error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@adobe/aio-lib-core-networking": "^5.0.2",
     "@adobe/aio-lib-env": "^3",
     "form-data": "^4.0.0",
-    "swagger-client": "~3.18.5"
+    "swagger-client": "^3.31.0"
   },
   "devDependencies": {
     "@adobe/aio-cli-plugin-certificate": "^2",


### PR DESCRIPTION
## Description

see https://github.com/adobe/aio-cli/issues/679

## How Has This Been Tested?

- npm i && npm test
- e2e test (same failures as in master branch, see https://github.com/adobe/aio-lib-console/issues/88)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
