### PR TITLE
fix: ACNA-3707 - (partial) check for function bindings for swagger spec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*   text eol=lf

--- a/src/index.js
+++ b/src/index.js
@@ -171,13 +171,14 @@ const API_HOST = {
  *      other than `prod` or `stage` it is assumed to be the default
  *      value of `prod`. If not set, it will get the global cli env value. See https://github.com/adobe/aio-lib-env
  *      (which defaults to `prod` as well if not set)
+ * @param {object} swaggerSpec the swagger spec for the API (optional)
  * @returns {Promise<CoreConsoleAPI>} a Promise with a CoreConsoleAPI object
  */
-function init (accessToken, apiKey, env = getCliEnv()) {
+function init (accessToken, apiKey, env = getCliEnv(), swaggerSpec) {
   return new Promise((resolve, reject) => {
     const clientWrapper = new CoreConsoleAPI()
 
-    clientWrapper.init(accessToken, apiKey, env)
+    clientWrapper.init(accessToken, apiKey, env, swaggerSpec)
       .then(initializedSDK => {
         logger.debug('sdk initialized successfully')
         resolve(initializedSDK)
@@ -205,12 +206,16 @@ class CoreConsoleAPI {
    *      other than `prod` or `stage` it is assumed to be the default
    *      value of `prod`. If not set, it will get the global cli env value. See https://github.com/adobe/aio-lib-env
    *      (which defaults to `prod` as well if not set)
+   * @param {object} swaggerSpec the swagger spec for the API (optional)
    * @returns {Promise<CoreConsoleAPI>} a CoreConsoleAPI object
    */
-  async init (accessToken, apiKey, env) {
+  async init (accessToken, apiKey, env, swaggerSpec) {
     const initErrors = []
     if (!accessToken) {
       initErrors.push('accessToken')
+    }
+    if (!swaggerSpec) {
+      swaggerSpec = require('../spec/api.json')
     }
 
     let apiHost = API_HOST[env]
@@ -224,9 +229,8 @@ class CoreConsoleAPI {
       throw new codes.ERROR_SDK_INITIALIZATION({ sdkDetails, messageValues: `${initErrors.join(', ')}` })
     } else {
       // init swagger client
-      const spec = require('../spec/api.json')
       const options = {
-        spec,
+        spec: swaggerSpec,
         requestInterceptor: requestInterceptorBuilder(this, apiHost),
         responseInterceptor,
         usePromise: true,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,6 +130,7 @@ async function standardTest ({
     sdkFunctionName = apiFunction
   }
   const fn = sdkClient[sdkFunctionName]
+  expect(typeof fn).toEqual('function')
   let mockFn
 
   // success case


### PR DESCRIPTION
Fixes #101 

Note that it does not do a comprehensive test of the bindings whether they exist, but takes a sample of the problematic xr-api function. There needs to be a re-factor (which expands the duration of this task) to do this test for all the lib functions, in the unit test.

The e2e tests should cover this - although they are not run automatically here: https://github.com/adobe/aio-e2e-tests

There are errors in e2e, there seems to be  regression in the Transporter API unrelated to the changes in this PR:

<details>
<summary>e2e results</summary>

```
 FAIL  e2e/e2e.js (37.727 s)
  init and input checks
    √ sdk init test (2 ms)
    √ bad access token (984 ms)
    √ bad api key (272 ms)
  organizations
    √ getOrganizations API (622 ms)
    √ getProjectsForOrg API (1648 ms)
  create, edit, get
    √ createFireflyProject API (560 ms)
    √ createProject API (default project type) (306 ms)
    √ editProject API (default project type) (319 ms)
    √ editProject API for firefly project (339 ms)
    √ getProject API (default type) (292 ms)
    √ getProject API (firefly project type) (294 ms)
    √ getApplicationExtensions (329 ms)
    √ createWorkspace API for default project type - should fail because only one is allowed for a default project (300 ms)
    √ deleteWorkspace API for default project type (to delete the default workspace) (1859 ms)
    √ createWorkspace API for default project type (343 ms)
    √ createWorkspace API for firefly project type (423 ms)
    √ update endpoints for workspace API (354 ms)
    √ get endpoints for workspace API (329 ms)
    √ getWorkspacesForProject API for firefly project type (312 ms)
    √ getWorkspacesForProject API for default project type (292 ms)
    × editWorkspace API for default project type (351 ms)
    × editWorkspace API for firefly project type (308 ms)
    × getWorkspace API for default project type (305 ms)
    × getWorkspace API for firefly project type (287 ms)
    √ getProjectForWorkspace API for default project type (303 ms)
    √ getProjectForWorkspace API for firefly project type (291 ms)
  Workspace credential test
    AdobeID credentials
      √ createAdobeIdCredential API (670 ms)
      √ getCredentials API (oauthweb) (301 ms)
      √ getWorkspaceForCredential API (309 ms)
      √ getIntegration API (536 ms)
      √ getIntegrationSecrets API (449 ms)
      √ deleteCredential API (integrationType: adobeid) (2671 ms)
      ○ skipped getAtlasApplicationPolicy API
      ○ skipped getAtlasQuotaUsage API
    OAuth Server-to-Server credentials
      √ createOAuthServerToServerCredential API (972 ms)
      √ getCredentials API (service) (296 ms)
      √ subscribeOAuthServerToServerIntegrationToServices API (AdobeIOManagementAPISDK) (1069 ms)
      √ downloadWorkspaceJson API (617 ms)
      √ getIntegration API (495 ms)
      √ getIntegrationSecrets API (422 ms)
      √ deleteCredential API (integrationType: oauth_server_to_server) (1211 ms)
  Extension API tests
    √ getAllExtensionPoints (360 ms)
  dev terms
    √ get dev terms (977 ms)
    √ check dev terms (289 ms)
    √ accept dev terms (404 ms)
  Organization Integration tests
    Enterprise integration
      ○ skipped createEnterpriseIntegration API
      ○ skipped getIntegrationsForOrg API (service)
      ○ skipped subscribeIntegrationToServices API (AdobeIOManagementAPISDK)
      ○ skipped deleteIntegration API (integrationType: entp)
    AdobeID integration
      ○ skipped createAdobeIdIntegration API
      ○ skipped getIntegrationsForOrg API (oauthweb)
      ○ skipped subscribeIntegrationToServices API (Adobe Stock)
      ○ skipped deleteIntegration API (integrationType: adobeid)
  create, edit, get, delete: test trailing spaces
    √ trailing spaces for firefly project (1314 ms)
    × trailing spaces for firefly workspace (991 ms)
    √ deleteProject API (default type) (1792 ms)
    √ deleteProject API (firefly project template) (2340 ms)
    √ delete (4825 ms)
```
</details>

## How Has This Been Tested

- npm test
- npm run e2e

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
